### PR TITLE
Start and end of event, adding some features, beautifying, closing is…

### DIFF
--- a/src/browser_action.css
+++ b/src/browser_action.css
@@ -14,6 +14,36 @@ body {
   margin: 0;
 }
 
+/* Customized Scrollbar */
+::-webkit-scrollbar {
+  /* Only show scrollbar-thumb with no background (clean appearance) */
+  background: transparent;
+  /* Same width as scrollbar from Google Calendar */
+  width: 8px;
+}
+
+::-webkit-scrollbar:hover {
+  /* Show "path" of scrollbar-thumb */
+  background-color: rgba(0, 0, 0, 0.07);
+}
+
+::-webkit-scrollbar-thumb {
+  /* A bit darker than the original, because of the extensions background */
+  background: #afafaf;
+  /* To make the scrollbar not too small.
+  Maybe in the future it is possible to load more and more events */
+  min-height: 40px;
+}
+
+/* Color changes on interaction */
+::-webkit-scrollbar-thumb:hover {
+  background: #a0a0a0
+}
+
+::-webkit-scrollbar-thumb:active {
+  background: #989898
+}
+
 textarea {
   border: 1px solid #ccc;
   font-size: 15px;
@@ -25,7 +55,7 @@ header {
   height: 48px;
   background: #0086f4;
   padding: 12px;
-  position: fixed;
+  position: relative;
   width: 100%;
   top: 0;
   left: 0;
@@ -33,8 +63,18 @@ header {
   z-index: 10;
 }
 
-.header-placeholder {
-  height: 48px;
+/* Separate section from <header>, so only the section is a scrollable area */
+.section-container {
+  display: flex;
+  overflow: hidden;
+  height: 432px;
+}
+
+section {
+  flex: 1;
+  overflow: auto;
+  height: auto;
+  padding: 0 8px;
 }
 
 .fab {
@@ -100,10 +140,6 @@ header {
   margin-bottom: 8px;
 }
 
-section {
-  padding: 0 8px;
-}
-
 #error {
   padding: 72px 12px;
   text-align: center;
@@ -128,6 +164,7 @@ section {
   margin: 8px 0;
   padding: 16px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+  border-radius: 2px;
 }
 
 h2 {
@@ -169,18 +206,21 @@ h2 {
   cursor: pointer;
   display: flex;
   margin: 0 0 4px 0;
+  border-radius: 2px;
   overflow: hidden;
   position: relative;
 }
 
 .start-time {
   color: #fff;
-  flex: 0 0 66px;
+  flex: 0 0 60px;
   font-size: 12px;
   overflow: hidden;
-  text-align: right;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  text-align: center;
+  /* Start and end times vertically aligned */
+  white-space: pre-line;
+  display: inline-flex;
+  align-items: center;
 }
 
 .start-and-end-times {

--- a/src/browser_action.html
+++ b/src/browser_action.html
@@ -27,28 +27,29 @@
         <img width="24" height="24" src="icons/ic_add_white_24dp.png" id="show_quick_add" class="i18n">
       </div>
     </header>
-    <div class="header-placeholder"></div>
-    <section>
-      <a id="announcement_new_features" class="i18n" href="https://github.com/manastungare/google-calendar-crx/wiki/Changes" target="_blank"></a>
-      <div id="info_bar"></div>
-      <div id="error">
-        <p class="i18n" id="authorization_explanation"></p>
-        <p><button class="button i18n" id="authorization_required"></button></p>
-        <p>
-          <a class="i18n" id="problems" target="_blank"
-              href="https://github.com/manastungare/google-calendar-crx/wiki/Troubleshooting">Problems?</a>
-        </p>
-      </div>
-      <div id="quick-add">
-        <h2 class="i18n" id="add_an_event">Add an Event</h2>
-        <select id="quick-add-calendar-list"/>
-        <textarea id="quick-add-event-title" rows="5" tabindex="1"></textarea>
-        <div class="quick-add-buttons">
-          <button id="quick_add_button" class="button i18n" tabindex="2">Quick Add</button>
+    <div class="section-container">
+      <section>
+        <a id="announcement_new_features" class="i18n" href="https://github.com/manastungare/google-calendar-crx/wiki/Changes" target="_blank"></a>
+        <div id="info_bar"></div>
+        <div id="error">
+          <p class="i18n" id="authorization_explanation"></p>
+          <p><button class="button i18n" id="authorization_required"></button></p>
+          <p>
+            <a class="i18n" id="problems" target="_blank"
+                href="https://github.com/manastungare/google-calendar-crx/wiki/Troubleshooting">Problems?</a>
+          </p>
         </div>
-      </div>
-      <div id="detected-events"></div>
-      <div id="calendar-events"></div>
-    </section>
+        <div id="quick-add">
+          <h2 class="i18n" id="add_an_event">Add an Event</h2>
+          <select id="quick-add-calendar-list"/>
+          <textarea id="quick-add-event-title" rows="5" tabindex="1"></textarea>
+          <div class="quick-add-buttons">
+            <button id="quick_add_button" class="button i18n" tabindex="2">Quick Add</button>
+          </div>
+        </div>
+        <div id="detected-events"></div>
+        <div id="calendar-events"></div>
+      </section>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
…sues (#488)

* Redesign scrollbar

* Separate <header> and <section> for more beautiful scrollbar

* More Google Calendar-like look

* Show start and end of event

#307 #308 #356

* Display not-"all day" events over multiple days as "all day" events

* Go to already existing Calendar tab, instead of creating one every time

#461

* Delete unnecessary CSS code

* add comments to CSS file

* Merge <section> CSS code

* More width for 12h format

* introduce "isMultiDayEventWithTime"

* Re-use tab; use constant; don't use tabs that are used to edit events

* Grammar, consistency, line width < 100

* line width < 100, formatted